### PR TITLE
add "varnishadm" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This addon also providers several helper commands. These helpers allow developer
 | Command | Description |
 | --- | --- |
 | `ddev varnishd` | Varnish-cli |
+| `ddev varnishadm` | Control a running Varnish instance |
 | `ddev varnishhist` | Display Varnish request histogram |
 | `ddev varnishlog` | Display Varnish logs |
 | `ddev varnishncsa` | Display Varnish logs in Apache / NCSA combined log format |

--- a/commands/varnish/varnishadm
+++ b/commands/varnish/varnishadm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Control a running Varnish instance
+## Usage: varnishadm [flags] [args]
+## Example: "ddev varnishadm"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishadm "$@"


### PR DESCRIPTION
This PR adds `ddev varnishadm` command.

This was originally overlook in #16.