### PR TITLE
Fix HEAD breakage with omit-container=dba being gone

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,11 @@ jobs:
 
     - name: Download docker images
       run: |
-        mkdir junk && pushd junk && (ddev config --omit-containers=dba,db >/dev/null 2>&1 || true ) && ddev debug download-images >/dev/null
+        mkdir junk && pushd junk
+        ddev config --omit-containers=db
+        # omit dba if pre v1.22.0
+        ddev config --omit-containers=db,dba >/dev/null 2>&1 || true
+        ddev debug download-images >/dev/null
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Download docker images
       run: |
-        mkdir junk && pushd junk && ddev config --omit-containers=dba,db && ddev debug download-images >/dev/null
+        mkdir junk && pushd junk && (ddev config --omit-containers=dba,db >/dev/null 2>&1 || true ) && ddev debug download-images >/dev/null
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -7,7 +7,9 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=dba,db >/dev/null 2>&1 || true
+  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=db
+  # dba is gone in v1.22.0, so try to do it but ignore results
+  ddev config --omit-containers=dba,db >/dev/null 2>&1 || true
   printf "<?php\nphpinfo();\n" >index.php
   ddev start >/dev/null
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -7,7 +7,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=dba,db >/dev/null
+  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=dba,db >/dev/null 2>&1 || true
   printf "<?php\nphpinfo();\n" >index.php
   ddev start >/dev/null
 }


### PR DESCRIPTION
## The Issue

In HEAD, `--omit-containers=dba` no longer works because `dba` has been removed.

## How This PR Solves The Issue

Ignore the error

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

