### PR TITLE
fix: make extra docker-compose always have correct primary hostname, fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Then restart your project
 ddev restart
 ```
 
+> [!NOTE]
+> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get ddev/ddev-varnish`
+
 ## Explanation
 
 The Varnish service inserts itself between ddev-router and the web container, so that calls

--- a/install.yaml
+++ b/install.yaml
@@ -38,21 +38,11 @@ post_install_actions:
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
     # container, just by switching the names.
-    {{- $project_tld := "ddev.site" -}}
-    {{- if .DdevGlobalConfig.project_tld }}{{ $project_tld = .DdevGlobalConfig.project_tld }}{{ end }}
-    {{- if .DdevProjectConfig.project_tld }}{{ $project_tld = .DdevProjectConfig.project_tld }}{{ end }}
-    {{- $novarnish_hostnames := print "novarnish." .DdevProjectConfig.name "." $project_tld -}}
-    {{- $sep := print "." $project_tld ",novarnish." -}}
-    {{- if .DdevProjectConfig.additional_hostnames }}
-    {{- $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." (.DdevProjectConfig.additional_hostnames | join $sep) "." $project_tld -}}
-    {{- end }}
-    {{- if .DdevProjectConfig.additional_fqdns }}
-    {{- $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." ( .DdevProjectConfig.additional_fqdns | join ",novarnish." ) -}}
-    {{- end }}
     services:
       web:
         environment:
-        - VIRTUAL_HOST={{ $novarnish_hostnames }}
+        {{- $novarnish_hostnames := splitList "," (env "DDEV_HOSTNAME") }}
+        - VIRTUAL_HOST={{ range $i, $n := $novarnish_hostnames }}novarnish.{{ replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) }}{{ if lt (add1 $i) (len $novarnish_hostnames) }},{{ end }}{{ end }}
     END
 
 removal_actions:

--- a/install.yaml
+++ b/install.yaml
@@ -28,16 +28,18 @@ pre_install_actions:
 post_install_actions:
   - |
     #ddev-nodisplay
+    #ddev-description:Checking docker-compose.varnish_extras.yaml for changes
     if [ -f docker-compose.varnish_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then
       echo "Existing docker-compose.varnish_extras.yaml does not have #ddev-generated, so can't be updated"
       exit 2
     fi
   - |
     #ddev-nodisplay
+    #ddev-description:Replacing all hostnames in the web container by adding "novarnish" subdomain prefix
     cat <<-END >docker-compose.varnish_extras.yaml
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
-    # container, just by switching the names.
+    # container, by switching all hostnames with "novarnish" subdomain prefix.
     services:
       web:
         environment:
@@ -48,6 +50,7 @@ post_install_actions:
 removal_actions:
   - |
     #ddev-nodisplay
+    #ddev-description:Remove docker-compose.varnish_extras.yaml file
     if [ -f docker-compose.varnish_extras.yaml ]; then
       if grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then
         rm -f docker-compose.varnish_extras.yaml


### PR DESCRIPTION
## The Issue

When changing a project name in `.ddev/config.yaml` because a git repository is used as a starterkit for other projects, it is easy to forgot that `.ddev/docker-compose.varnish-extras.yaml` has a VIRTUAL_HOST hardcoded with the starterkit value.

## How This PR Solves The Issue

Replacing the previously generated hostname with `VIRTUAL_HOST=novarnish.${DDEV_PROJECT}.${DDEV_TLD},novarnish.extra.${DDEV_TLD},...` avoids to have to change that for every project.

## Manual Testing Instructions

This allows for example to have Mailpit to work automatically without any port change.

```
mkdir varnish-test && cd varnish-test
ddev config --additional-fqdns="hello.test" --additional-hostnames "extra1,extra2,more.extra"
ddev add-on get https://github.com/FlorentTorregrosa/ddev-varnish/tarball/21

cat .ddev/docker-compose.varnish_extras.yaml
#  - VIRTUAL_HOST=novarnish.${DDEV_PROJECT}.${DDEV_TLD},novarnish.extra1.${DDEV_TLD},novarnish.extra2.${DDEV_TLD},novarnish.hello.test,novarnish.more.extra.${DDEV_TLD}

ddev start
ddev exec echo '$VIRTUAL_HOST'
# novarnish.varnish-test.ddev.site,novarnish.extra1.ddev.site,novarnish.extra2.ddev.site,novarnish.hello.test,novarnish.more.extra.ddev.site
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

https://github.com/ddev/ddev-varnish/issues/21

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

