### PR TITLE
fix: remove empty lines from docker-compose.varnish_extras.yaml, fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This repository allows you to quickly install the Varnish reverse proxy into a [
 ## Explanation
 
 The Varnish service inserts itself between ddev-router and the web container, so that calls
-to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/varnish/docker-compose.varnish.yml)
-installs Varnish and uses the default domain as its own host name. A docker-compose.varnish_extras.yaml file is generated on install which replaces the ```VIRTUAL_HOST``` variable of the web container with a sub-domain of the website URL. For example, mysite.ddev.site, would be accessible via Varnish on mysite.ddev.site and directly on novarnish.mysite.ddev.site.
+to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](docker-compose.varnish.yaml)
+installs Varnish and uses the default domain as its own host name. A `docker-compose.varnish_extras.yaml` file is generated on install which replaces the `VIRTUAL_HOST` variable of the web container with a sub-domain of the website URL. For example, `mysite.ddev.site`, would be accessible via Varnish on `mysite.ddev.site` and directly on `novarnish.mysite.ddev.site`.
 
-If you use a project_tld other than ddev.site or additional_fqdns DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the novarnish.* sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
+If you use a `project_tld` other than `ddev.site` or `additional_fqdns` DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the `novarnish.*` sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
 
-Run `ddev get ddev/ddev-varnish` after changes to name, additional_hostnames, additional_fqdns, or project_tld in .ddev/config.yml so that .ddev/docker-compose.varnish_extras.yaml is regenerated.
+Run `ddev get ddev/ddev-varnish` after changes to `name`, `additional_hostnames`, `additional_fqdns`, or `project_tld` in `.ddev/config.yaml` so that `.ddev/docker-compose.varnish_extras.yaml` is regenerated.
 
 ## Helper commands
 
@@ -38,8 +38,8 @@ See [The Varnish Reference Manual](https://varnish-cache.org/docs/6.5/reference/
 
 ## Additional Configuration
 
-* You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove '#ddev-generated' from the file if you want your changes to the file preserved.
+* You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove `#ddev-generated` from the file if you want your changes to the file preserved.
 
-**Maintained by [@jedebois](https://github.com/jedubois) and [@rfay](https://github.com/rfay)**
+**Maintained by [@jedubois](https://github.com/jedubois) and [@rfay](https://github.com/rfay)**
 
 **Based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/varnish) pioneered by [rikwillems](https://github.com/rikwillems)**

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This repository allows you to quickly install the Varnish reverse proxy into a [
 
 The Varnish service inserts itself between ddev-router and the web container, so that calls
 to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/varnish/docker-compose.varnish.yml)
-installs Varnish and uses the default domain as its own host name. A docker-compose.varnish-extras.yaml file is generated on install which replaces the ```VIRTUAL_HOST``` variable of the web container with a sub-domain of the website URL. For example, mysite.ddev.site, would be accessible via Varnish on mysite.ddev.site and directly on novarnish.mysite.ddev.site.
+installs Varnish and uses the default domain as its own host name. A docker-compose.varnish_extras.yaml file is generated on install which replaces the ```VIRTUAL_HOST``` variable of the web container with a sub-domain of the website URL. For example, mysite.ddev.site, would be accessible via Varnish on mysite.ddev.site and directly on novarnish.mysite.ddev.site.
 
 If you use a project_tld other than ddev.site or additional_fqdns DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the novarnish.* sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
 
-Run `ddev get ddev/ddev-varnish` after changes to name, additional_hostnames, additional_fqdns, or project_tld in .ddev/config.yml so that .ddev/docker-compose.varnish-extras.yaml is regenerated.
+Run `ddev get ddev/ddev-varnish` after changes to name, additional_hostnames, additional_fqdns, or project_tld in .ddev/config.yml so that .ddev/docker-compose.varnish_extras.yaml is regenerated.
 
 ## Helper commands
 

--- a/install.yaml
+++ b/install.yaml
@@ -16,13 +16,13 @@ pre_install_actions:
 post_install_actions:
   - |
     #ddev-nodisplay
-    if [ -f .ddev/docker-compose.varnish-extras.yaml ] && ! grep '#ddev-generated' .ddev/config.varnish-extras.yaml; then
-      echo "Existing docker-compose.varnish-extras.yaml does not have #ddev-generated, so can't be updated"
+    if [ -f .ddev/docker-compose.varnish_extras.yaml ] && ! grep '#ddev-generated' .ddev/docker-compose.varnish_extras.yaml; then
+      echo "Existing docker-compose.varnish_extras.yaml does not have #ddev-generated, so can't be updated"
     exit 2
     fi
   - |
     #ddev-nodisplay
-    cat <<-END | grep -v '^$' >docker-compose.varnish-extras.yaml
+    cat <<-END | grep -v '^$' >docker-compose.varnish_extras.yaml
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
     # container, just by switching the names.

--- a/install.yaml
+++ b/install.yaml
@@ -22,7 +22,7 @@ post_install_actions:
     fi
   - |
     #ddev-nodisplay
-    cat  <<-END >docker-compose.varnish-extras.yaml
+    cat <<-END | grep -v '^$' >docker-compose.varnish-extras.yaml
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
     # container, just by switching the names.

--- a/install.yaml
+++ b/install.yaml
@@ -12,13 +12,25 @@ pre_install_actions:
     #ddev-nodisplay
     #ddev-description:Checking DDEV version
     (ddev debug capabilities | grep ddev-get-yaml-interpolation >/dev/null) || (echo "Please upgrade DDEV to v1.21.4+ for appropriate capabilities" && false)
+    # Make sure we have a ddev version that can support what we do here
+  - |
+    #ddev-nodisplay
+    #ddev-description:Removing old docker-compose.varnish-extras.yaml
+    if [ -f ${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml ]; then
+      if grep -q '#ddev-generated' ${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml; then
+        rm -f ${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml
+      else
+        echo "${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml needs to be removed but has been modified by the user. Please check it and remove it"
+        exit 2
+      fi
+    fi
 
 post_install_actions:
   - |
     #ddev-nodisplay
-    if [ -f .ddev/docker-compose.varnish_extras.yaml ] && ! grep '#ddev-generated' .ddev/docker-compose.varnish_extras.yaml; then
+    if [ -f docker-compose.varnish_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then
       echo "Existing docker-compose.varnish_extras.yaml does not have #ddev-generated, so can't be updated"
-    exit 2
+      exit 2
     fi
   - |
     #ddev-nodisplay
@@ -42,3 +54,14 @@ post_install_actions:
         environment:
         - VIRTUAL_HOST={{ $novarnish_hostnames }}
     END
+
+removal_actions:
+  - |
+    #ddev-nodisplay
+    if [ -f docker-compose.varnish_extras.yaml ]; then
+      if grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then
+        rm -f docker-compose.varnish_extras.yaml
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.varnish_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi

--- a/install.yaml
+++ b/install.yaml
@@ -22,24 +22,23 @@ post_install_actions:
     fi
   - |
     #ddev-nodisplay
-    cat <<-END | grep -v '^$' >docker-compose.varnish_extras.yaml
+    cat <<-END >docker-compose.varnish_extras.yaml
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
     # container, just by switching the names.
-    {{ $project_tld := "ddev.site" }}
-    {{ if .DdevGlobalConfig.project_tld }}{{ $project_tld = .DdevGlobalConfig.project_tld }}{{ end }}
-    {{ if .DdevProjectConfig.project_tld }}{{ $project_tld = .DdevProjectConfig.project_tld }} {{ end }}
-    {{ $novarnish_hostnames := print "novarnish." .DdevProjectConfig.name "." $project_tld  }}
-    {{ $sep := print "." $project_tld ",novarnish." }}
-    {{ if .DdevProjectConfig.additional_hostnames }}
-    {{ $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." (.DdevProjectConfig.additional_hostnames | join $sep) "." $project_tld }}
-    {{ end }}
-    {{ if .DdevProjectConfig.additional_fqdns }}
-    {{ $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." ( .DdevProjectConfig.additional_fqdns | join ",novarnish." )   }}
-    {{ end }}
+    {{- $project_tld := "ddev.site" -}}
+    {{- if .DdevGlobalConfig.project_tld }}{{ $project_tld = .DdevGlobalConfig.project_tld }}{{ end }}
+    {{- if .DdevProjectConfig.project_tld }}{{ $project_tld = .DdevProjectConfig.project_tld }}{{ end }}
+    {{- $novarnish_hostnames := print "novarnish." .DdevProjectConfig.name "." $project_tld -}}
+    {{- $sep := print "." $project_tld ",novarnish." -}}
+    {{- if .DdevProjectConfig.additional_hostnames }}
+    {{- $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." (.DdevProjectConfig.additional_hostnames | join $sep) "." $project_tld -}}
+    {{- end }}
+    {{- if .DdevProjectConfig.additional_fqdns }}
+    {{- $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." ( .DdevProjectConfig.additional_fqdns | join ",novarnish." ) -}}
+    {{- end }}
     services:
       web:
         environment:
         - VIRTUAL_HOST={{ $novarnish_hostnames }}
-
     END


### PR DESCRIPTION
## The Issue

- #24

## How This PR Solves The Issue

Removes empty lines using go templates `{{- -}}`
Renames `docker-compose.varnish-extras.yaml` to `docker-compose.varnish_extras.yaml`

## Manual Testing Instructions

```
ddev get https://github.com/ddev/ddev-varnish/tarball/20240704_stasadev_remove_empty_lines
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

