### PR TITLE
fix: use dynamic ports for router and mailpit, fixes #23

### DIFF
--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -15,8 +15,8 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # This defines the ports the service should be accessible from at
       # sitename.ddev.site.
-      - HTTPS_EXPOSE=443:80,8026:8025
-      - HTTP_EXPOSE=80:80,8025:8025
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,8026:8025
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,8025:8025
     volumes:
       # This exposes a mount to the host system `.ddev/varnish` directory where
       # your default.vcl should be.

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -15,8 +15,8 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       # This defines the ports the service should be accessible from at
       # sitename.ddev.site.
-      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,8026:8025
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,8025:8025
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILPIT_HTTPS_PORT}:8025
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILPIT_PORT}:8025
     volumes:
       # This exposes a mount to the host system `.ddev/varnish` directory where
       # your default.vcl should be.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -44,6 +44,30 @@ teardown() {
   curl -sI "https://${PROJNAME}.ddev.site:8026" | grep -i "https://novarnish.${PROJNAME}.ddev.site:8026/" >/dev/null || (echo "# https://${PROJNAME}.ddev.site:8026 did not redirect" >&3 && exit 1);
 }
 
+@test "install from directory with nonstandard port" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  ddev config --router-http-port 8080 --router-https-port 8443 --mailpit-http-port 18025 --mailpit-https-port 18026
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR} >/dev/null
+  ddev restart >/dev/null 2>&1
+  for url in http://${PROJNAME}.ddev.site:8080/ http://extrahostname.ddev.site:8080/ http://extrafqdn.ddev.site:8080/ https://${PROJNAME}.ddev.site:8443/ https://extrahostname.ddev.site:8443/ https://extrafqdn.ddev.site:8443/ ; do
+    # It's "Via:" with http and "via:" with https. Tell me why.
+    echo "# test $url for via:.*varnish header" >&3
+    curl -sI $url | grep -i "Via:.*varnish" >/dev/null || (echo "# varnish headers not shown for $url"  >&3 && exit 1);
+    echo "# test $url for phpinfo content" >&3
+    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+  done
+  for url in http://novarnish.${PROJNAME}.ddev.site:8080/ http://novarnish.extrahostname.ddev.site:8080/ http://novarnish.extrafqdn.ddev.site:8080/ https://novarnish.${PROJNAME}.ddev.site:8443/ https://novarnish.extrahostname.ddev.site:8443/ https://novarnish.extrafqdn.ddev.site:8443/ ; do
+    echo "# test $url for phpinfo content" >&3
+    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+  done
+  echo "# test http://${PROJNAME}.ddev.site:18025 for http novarnish redirect" >&3
+  curl -sI "http://${PROJNAME}.ddev.site:18025" | grep -i "http://novarnish.${PROJNAME}.ddev.site:18025/" >/dev/null || (echo "# http://${PROJNAME}.ddev.site:18025 did not redirect" >&3 && exit 1);
+  echo "# test https://${PROJNAME}.ddev.site:18026 for https novarnish redirect" >&3
+  curl -sI "https://${PROJNAME}.ddev.site:18026" | grep -i "https://novarnish.${PROJNAME}.ddev.site:18026/" >/dev/null || (echo "# https://${PROJNAME}.ddev.site:18026 did not redirect" >&3 && exit 1);
+}
+
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )


### PR DESCRIPTION
## The Issue
Issue #23 
## How This PR Solves The Issue
Updated the docker-compose.varnish.yaml file to use environment variables (`DDEV_ROUTER_HTTPS_PORT` and `DDEV_ROUTER_HTTP_PORT`) for dynamic port configuration.
This change ensures compatibility with custom DDEV port settings and resolves issues when default ports are unavailable
## Manual Testing Instructions

```
ddev config --router-http-port 8080 --router-https-port 8443 --mailpit-http-port 18025 --mailpit-https-port 18026
ddev add-on get https://github.com/zeshanziya/ddev-varnish/tarball/dynamic-router-ports
ddev restart
```

And look inside:

```
cat .ddev/.ddev-docker-compose-full.yaml
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

