### PR TITLE
feat: update setup for 2025

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,16 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Debug with tmate set "debug_enabled"'
+        type: boolean
+        description: Debug with tmate
         required: false
-        default: "false"
+        default: false
 
-env:
-  # Allow ddev get to use a github token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write
 
@@ -32,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
 
 # ddev-varnish
 

--- a/install.yaml
+++ b/install.yaml
@@ -6,13 +6,9 @@ project_files:
 - varnish
 - commands/varnish
 
+ddev_version_constraint: '>= v1.24.0'
+
 pre_install_actions:
-    # Make sure we have a ddev version that can support what we do here
-  - |
-    #ddev-nodisplay
-    #ddev-description:Checking DDEV version
-    (ddev debug capabilities | grep ddev-get-yaml-interpolation >/dev/null) || (echo "Please upgrade DDEV to v1.21.4+ for appropriate capabilities" && false)
-    # Make sure we have a ddev version that can support what we do here
   - |
     #ddev-nodisplay
     #ddev-description:Removing old docker-compose.varnish-extras.yaml

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,19 +4,17 @@ setup() {
   export TESTDIR=~/tmp/testvarnish
   mkdir -p $TESTDIR
   export PROJNAME=test-varnish
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=db
-  # dba is gone in v1.22.0, so try to do it but ignore results
-  ddev config --omit-containers=dba,db >/dev/null 2>&1 || true
   printf "<?php\nphpinfo();\n" >index.php
-  ddev start >/dev/null
+  ddev start -y >/dev/null
 }
 
 teardown() {
   set -eu -o pipefail
-  cd ${TESTDIR} || (printf "unable to cd to ${TESTDIR}\n" && exit 1)
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
@@ -24,8 +22,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} >/dev/null
   ddev restart >/dev/null 2>&1
   for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ http://extrafqdn.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/ https://extrafqdn.ddev.site/ ; do
     # It's "Via:" with http and "via:" with https. Tell me why.
@@ -48,8 +46,8 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   ddev config --router-http-port 8080 --router-https-port 8443 --mailpit-http-port 18025 --mailpit-https-port 18026
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} >/dev/null
   ddev restart >/dev/null 2>&1
   for url in http://${PROJNAME}.ddev.site:8080/ http://extrahostname.ddev.site:8080/ http://extrafqdn.ddev.site:8080/ https://${PROJNAME}.ddev.site:8443/ https://extrahostname.ddev.site:8443/ https://extrafqdn.ddev.site:8443/ ; do
     # It's "Via:" with http and "via:" with https. Tell me why.
@@ -68,11 +66,12 @@ teardown() {
   curl -sI "https://${PROJNAME}.ddev.site:18026" | grep -i "https://novarnish.${PROJNAME}.ddev.site:18026/" >/dev/null || (echo "# https://${PROJNAME}.ddev.site:18026 did not redirect" >&3 && exit 1);
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-varnish with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-varnish >/dev/null
+  echo "# ddev add-on get ddev/ddev-varnish with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ddev/ddev-varnish >/dev/null
   ddev restart >/dev/null 2>&1
   for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ http://extrafqdn.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/ https://extrafqdn.ddev.site/ ; do
     # It's "Via:" with http and "via:" with https. Tell me why.


### PR DESCRIPTION
## The Issue

We have some changes upstream. Like `ddev add-on get` instead of `ddev get` and so on.

## How This PR Solves The Issue

Updates the repository.

Bumps version constraint to v1.24.0

## Manual Testing Instructions

```
ddev add-on get https://github.com/ddev/ddev-varnish/tarball/20250121_stasadev_chores
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

