### PR TITLE
refactor: use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/commands/varnish/varnishadm
+++ b/commands/varnish/varnishadm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Control a running Varnish instance

--- a/commands/varnish/varnishd
+++ b/commands/varnish/varnishd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Varnish-cli

--- a/commands/varnish/varnishhist
+++ b/commands/varnish/varnishhist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Display Varnish request histogram

--- a/commands/varnish/varnishlog
+++ b/commands/varnish/varnishlog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Display Varnish logs

--- a/commands/varnish/varnishncsa
+++ b/commands/varnish/varnishncsa
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Display Varnish logs in Apache / NCSA combined log format

--- a/commands/varnish/varnishstat
+++ b/commands/varnish/varnishstat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Display Varnish Cache statistics

--- a/commands/varnish/varnishtest
+++ b/commands/varnish/varnishtest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Test program for Varnish

--- a/commands/varnish/varnishtop
+++ b/commands/varnish/varnishtop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Display Varnish log entry ranking


### PR DESCRIPTION
## The Issue

`/bin/bash` doesn't work on NixOS.

## How This PR Solves The Issue

Uses `/usr/bin/env bash`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-varnish/tarball/20250417_stasadev_bash
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
