### PR TITLE
refactor: update README.md, add `--varnish-docker-image` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,39 @@
-[![tests](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
+[![tests](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-varnish/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-varnish)](https://github.com/ddev/ddev-varnish/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-varnish)](https://github.com/ddev/ddev-varnish/releases/latest)
 
-# ddev-varnish
+# DDEV Adminer
 
-This repository allows you to quickly install the Varnish reverse proxy into a [DDEV](https://ddev.readthedocs.io) project using the instructions below.
+## Overview
+
+[Varnish Cache](https://varnish-cache.org/) is a web application accelerator also known as a caching HTTP reverse proxy. You install it in front of any server that speaks HTTP and configure it to cache the contents. Varnish Cache is really, really fast. It typically speeds up delivery with a factor of 300 - 1000x, depending on your architecture.
+
+This add-on integrates Varnish into your [DDEV](https://ddev.com/) project.
 
 ## Installation
 
-For DDEV v1.23.5 or above run
-
-```sh
+```bash
 ddev add-on get ddev/ddev-varnish
-```
-
-For earlier versions of DDEV run
-
-```sh
-ddev get ddev/ddev-varnish
-```
-
-Then restart your project
-
-```sh
 ddev restart
 ```
 
 > [!NOTE]
-> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get ddev/ddev-varnish`
+> Run `ddev add-on get ddev/ddev-varnish` after changes to `name`, `additional_hostnames`, `additional_fqdns`, or `project_tld` in `.ddev/config.yaml` so that `.ddev/docker-compose.varnish_extras.yaml` is regenerated.
 
-## Explanation
+After installation, make sure to commit the `.ddev` directory to version control.
 
-The Varnish service inserts itself between ddev-router and the web container, so that calls
-to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](docker-compose.varnish.yaml)
-installs Varnish and uses the default domain as its own host name. A `docker-compose.varnish_extras.yaml` file is generated on install which replaces the `VIRTUAL_HOST` variable of the web container with a sub-domain of the website URL. For example, `mysite.ddev.site`, would be accessible via Varnish on `mysite.ddev.site` and directly on `novarnish.mysite.ddev.site`.
+## Usage
+
+The Varnish service inserts itself between ddev-router and the web container, so that calls to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](docker-compose.varnish.yaml) installs Varnish and uses the default domain as its own host name.
+
+A `docker-compose.varnish_extras.yaml` file is generated on install which replaces the `VIRTUAL_HOST` variable of the web container with a sub-domain of the website URL. For example, `mysite.ddev.site`, would be accessible via Varnish on `mysite.ddev.site` and directly on `novarnish.mysite.ddev.site`.
 
 If you use a `project_tld` other than `ddev.site` or `additional_fqdns` DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the `novarnish.*` sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
 
-Run `ddev add-on get ddev/ddev-varnish` after changes to `name`, `additional_hostnames`, `additional_fqdns`, or `project_tld` in `.ddev/config.yaml` so that `.ddev/docker-compose.varnish_extras.yaml` is regenerated.
+## Helper Commands
 
-## Helper commands
-
-This addon also providers several helper commands. These helpers allow developers to run Varnish commands from the host, however, the commands are actually run inside the Varnish container.
+This add-on also providers several helper commands. These helpers allow developers to run Varnish commands from the host, however, the commands are actually run inside the Varnish container.
 
 | Command | Description |
 | --- | --- |
@@ -51,13 +45,32 @@ This addon also providers several helper commands. These helpers allow developer
 | `ddev varnishstat` | Display Varnish Cache statistics |
 | `ddev varnishtest` | Test program for Varnish |
 | `ddev varnishtop` | Display Varnish log entry ranking |
+| `ddev logs -s varnish` | Check Varnish logs |
 
-See [The Varnish Reference Manual](https://varnish-cache.org/docs/6.5/reference/index.html) for more information about the commands, their flags, and their arguments.
+See [The Varnish Reference Manual](https://varnish-cache.org/docs/6.0/reference/index.html) for more information about the commands, their flags, and their arguments.
 
-## Additional Configuration
+## Advanced Customization
 
-* You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove `#ddev-generated` from the file if you want your changes to the file preserved.
+You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove `#ddev-generated` from the file if you want your changes to the file preserved.
 
-**Maintained by [@jedubois](https://github.com/jedubois) and [@rfay](https://github.com/rfay)**
+To change the Docker image:
+
+```bash
+ddev dotenv set .ddev/.env.varnish --varnish-docker-image=varnish:6.0
+ddev add-on get ddev/ddev-varnish
+ddev restart
+```
+
+Make sure to commit the `.ddev/.env.varnish` file to version control.
+
+All customization options (use with caution):
+
+| Variable | Flag | Default |
+| -------- | ---- | ------- |
+| `VARNISH_DOCKER_IMAGE` | `--varnish-docker-image` | `varnish:6.0` |
+
+## Credits
+
+**Maintained by [@jedubois](https://github.com/jedubois) and the [DDEV team](https://ddev.com/support-ddev/)**
 
 **Based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/varnish) pioneered by [rikwillems](https://github.com/rikwillems)**

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -2,7 +2,7 @@
 services:
   varnish:
     container_name: ddev-${DDEV_SITENAME}-varnish
-    image: varnish:6.0
+    image: ${VARNISH_DOCKER_IMAGE:-varnish:6.0}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -24,7 +24,7 @@ services:
       - ".:/mnt/ddev_config"
     depends_on:
       - web
-    # Add mailhog support
+    # Add mailpit support
     expose:
       - "8025"
     entrypoint:


### PR DESCRIPTION
## The Issue

Changes from upstream.

## How This PR Solves The Issue

- Updates the README.md with new badges.
- Adds `--varnish-docker-image` flag.

## Manual Testing Instructions

```bash
ddev dotenv set .ddev/.env.varnish --varnish-docker-image=varnish:6.0
ddev add-on get https://github.com/ddev/ddev-varnish/tarball/20250417_stasadev_readme
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
