### PR TITLE
feat: Provide environment variable to customize varnishd startup parameters and increase limits, fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,23 @@ Make sure to commit the `.ddev/.env.varnish` file to version control.
 
 All customization options (use with caution):
 
-| Variable | Flag | Default |
-| -------- | ---- | ------- |
-| `VARNISH_DOCKER_IMAGE` | `--varnish-docker-image` | `varnish:6.0` |
+| Variable                  | Flag                        | Default                                                                                                            |
+|---------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `VARNISH_DOCKER_IMAGE`    | `--varnish-docker-image`    | `varnish:6.0`                                                                                                      |
+| `VARNISH_VARNISHD_PARAMS` | `--varnish-varnishd-params` | `-p http_max_hdr=1000 -p http_resp_hdr_len=1M -p http_resp_size=2M -p workspace_backend=3M -p workspace_client=3M` |
+
+### VARNISH_VARNISHD_PARAMS
+
+Allows modifying the varnish [startup parameters](https://varnish-cache.org/docs/6.0/reference/varnishd.html).
+
+The provided defaults are set deliberately higher than what varnish usually defines.
+The reason for this is that in development environments it is not uncommon to
+have larger payloads either in HTML or HTTP-Headers. E.g. Drupals theme debugging
+or cache tag handling.
+Without increasing these limits, one might encounter hard to isolate errors like the following form nginx:
+```
+2025/07/15 09:01:01 [info] 1549#1549: *259 writev() failed (32: Broken pipe) while sending to client, client: 172.20.0.6, server: , request: "GET /en HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "myproject.ddev.site"
+```
 
 ## Credits
 

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -28,4 +28,4 @@ services:
     expose:
       - "8025"
     entrypoint:
-      /usr/local/bin/docker-varnish-entrypoint -a 0.0.0.0:8025
+      /usr/local/bin/docker-varnish-entrypoint -a 0.0.0.0:8025 ${VARNISH_VARNISHD_PARAMS:--p http_max_hdr=1000 -p http_resp_hdr_len=1M -p http_resp_size=2M -p workspace_backend=3M -p workspace_client=3M}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -149,9 +149,6 @@ teardown() {
   run ddev restart -y
   assert_success
   export ROUTER_HTTP_PORT=80 ROUTER_HTTPS_PORT=443 MAILPIT_HTTP_PORT=8025 MAILPIT_HTTPS_PORT=8026 
-  export CUSTOM_VARNISH_VARNISHD_PARAMS=false
+  export CUSTOM_VARNISH_VARNISHD_PARAMS=true
   health_checks
-  run ddev varnishadm param.show http_max_hdr
-  assert_output --partial 'Value is: 123 [header lines]'
-  assert_success
 }


### PR DESCRIPTION
## The Issue

- #41

It would be nice to be able to easily adjust the varnish startup parameters.
Env-Variables are a bit more intuitive than docker compose file creation.
Further I think it would be beneficial to increase the default varnishd limits for http headers and payload sizes.
These payloads often are larger on development environments and can cause hard to track issues.

## How This PR Solves The Issue

Adds a env-variable for the parameters and defines larger limits by defaiult.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/CandoImage/ddev-varnish/tarball/20250721_das-peter_41_provide-env-var-to-set-varnishd-parameters
ddev dotenv set .ddev/.env.varnish --varnish-varnishd-params='-p http_max_hdr=12345'
ddev restart
ddev varnishadm param.show http_max_hdr
```

## Automated Testing Overview

Added new test to check if customization is picked up:
`bats ./tests/test.bats --filter "customize varnishd startup parameters" `

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
