### PR TITLE
feat: use Varnish only for `web:80`, remove novarnish subdomains, fixes #32

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-varnish/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:
@@ -19,9 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ddev restart
 ```
 
 > [!NOTE]
-> Run `ddev add-on get ddev/ddev-varnish` after changes to `name`, `additional_hostnames`, `additional_fqdns`, or `project_tld` in `.ddev/config.yaml` so that `.ddev/docker-compose.varnish_extras.yaml` is regenerated.
+> Run `ddev add-on get ddev/ddev-varnish` after changes in the Mailpit ports or `web_extra_exposed_ports` in `.ddev/config.yaml` so that `.ddev/docker-compose.varnish_extras.yaml` is regenerated.
 
 After installation, make sure to commit the `.ddev` directory to version control.
 
@@ -27,9 +27,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 The Varnish service inserts itself between ddev-router and the web container, so that calls to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](docker-compose.varnish.yaml) installs Varnish and uses the default domain as its own host name.
 
-A `docker-compose.varnish_extras.yaml` file is generated on install which replaces the `VIRTUAL_HOST` variable of the web container with a sub-domain of the website URL. For example, `mysite.ddev.site`, would be accessible via Varnish on `mysite.ddev.site` and directly on `novarnish.mysite.ddev.site`.
-
-If you use a `project_tld` other than `ddev.site` or `additional_fqdns` DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the `novarnish.*` sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
+A `docker-compose.varnish_extras.yaml` file is generated on install which replaces the `HTTP_EXPOSE` and `HTTPS_EXPOSE` variables of the web container to exclude non-webserver ports from Varnish.
 
 ## Helper Commands
 

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -6,17 +6,11 @@ services:
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
     environment:
-      # This defines the host name the service should be accessible from. This
-      # will be sitename.ddev.site.
-      # This is the first half of the trick that puts varnish "in front of" the
-      # web container, just by switching the names.
-      - VIRTUAL_HOST=$DDEV_HOSTNAME
-      # This defines the ports the service should be accessible from at
-      # sitename.ddev.site.
-      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILPIT_HTTPS_PORT}:8025
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILPIT_PORT}:8025
+      - VIRTUAL_HOST=${DDEV_HOSTNAME}
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80
     volumes:
       # This exposes a mount to the host system `.ddev/varnish` directory where
       # your default.vcl should be.
@@ -24,8 +18,4 @@ services:
       - ".:/mnt/ddev_config"
     depends_on:
       - web
-    # Add mailpit support
-    expose:
-      - "8025"
-    entrypoint:
-      /usr/local/bin/docker-varnish-entrypoint -a 0.0.0.0:8025 ${VARNISH_VARNISHD_PARAMS:--p http_max_hdr=1000 -p http_resp_hdr_len=1M -p http_resp_size=2M -p workspace_backend=3M -p workspace_client=3M}
+    entrypoint: docker-varnish-entrypoint ${VARNISH_VARNISHD_PARAMS:--p http_max_hdr=1000 -p http_resp_hdr_len=1M -p http_resp_size=2M -p workspace_backend=3M -p workspace_client=3M}

--- a/install.yaml
+++ b/install.yaml
@@ -9,7 +9,6 @@ ddev_version_constraint: '>= v1.24.3'
 
 pre_install_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Removing old docker-compose.varnish-extras.yaml
     if [ -f ${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml ]; then
       if grep -q '#ddev-generated' ${DDEV_APPROOT}/.ddev/docker-compose.varnish-extras.yaml; then
@@ -22,29 +21,36 @@ pre_install_actions:
 
 post_install_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Checking docker-compose.varnish_extras.yaml for changes
     if [ -f docker-compose.varnish_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then
       echo "Existing docker-compose.varnish_extras.yaml does not have #ddev-generated, so can't be updated"
       exit 2
     fi
   - |
-    #ddev-nodisplay
-    #ddev-description:Replacing all hostnames in the web container by adding "novarnish" subdomain prefix
-    cat <<-END >docker-compose.varnish_extras.yaml
+    #ddev-description:Modify HTTP_EXPOSE and HTTPS_EXPOSE for web container
+    cat <<'EOF' > docker-compose.varnish_extras.yaml
     #ddev-generated
-    # This is the second half of the trick that puts varnish "in front of" the web
-    # container, by switching all hostnames with "novarnish" subdomain prefix.
+    # This configuration modifies HTTP_EXPOSE and HTTPS_EXPOSE for web container
+    # to exclude 80 port, which is handled by Varnish.
     services:
       web:
         environment:
-        {{- $novarnish_hostnames := splitList "," (env "DDEV_HOSTNAME") }}
-        - VIRTUAL_HOST={{ range $i, $n := $novarnish_hostnames }}novarnish.{{ replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) }}{{ if lt (add1 $i) (len $novarnish_hostnames) }},{{ end }}{{ end }}
-    END
+          {{- $base_http_ports := list (printf "%s:8025" (or (index .DdevProjectConfig "mailpit_http_port") (env "DDEV_MAILPIT_PORT"))) }}
+          {{- $base_https_ports := list (printf "%s:8025" (or (index .DdevProjectConfig "mailpit_https_port") (env "DDEV_MAILPIT_HTTPS_PORT"))) }}
+          {{- $extra_http_ports := list }}
+          {{- $extra_https_ports := list }}
+          {{- range .DdevProjectConfig.web_extra_exposed_ports }}
+          {{- $extra_http_ports = append $extra_http_ports (printf "%d:%d" .http_port .container_port) }}
+          {{- $extra_https_ports = append $extra_https_ports (printf "%d:%d" .https_port .container_port) }}
+          {{- end }}
+          {{- $all_http_ports := concat $base_http_ports $extra_http_ports }}
+          {{- $all_https_ports := concat $base_https_ports $extra_https_ports }}
+          - HTTP_EXPOSE={{ range $i, $p := $all_http_ports }}{{ $p }}{{ if lt (add1 $i) (len $all_http_ports) }},{{ end }}{{ end }}
+          - HTTPS_EXPOSE={{ range $i, $p := $all_https_ports }}{{ $p }}{{ if lt (add1 $i) (len $all_https_ports) }},{{ end }}{{ end }}
+    EOF
 
 removal_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Remove docker-compose.varnish_extras.yaml file
     if [ -f docker-compose.varnish_extras.yaml ]; then
       if grep -q '#ddev-generated' docker-compose.varnish_extras.yaml; then

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -3,25 +3,8 @@
 # For a more advanced example see https://github.com/mattiasgeniar/varnish-6.0-configuration-templates
 
 vcl 4.1;
-import std;
 
 backend default {
   .host = "web";
   .port = "80";
-}
-
-
-sub vcl_recv {
-  if (std.port(server.ip) == 8025) {
-    return (synth(750));
-  }
-}
-
-sub vcl_synth {
-  if (resp.status == 750) {
-    set resp.status = 301;
-    set resp.http.location = req.http.X-Forwarded-Proto + "://novarnish." + req.http.Host + req.url;
-    set resp.reason = "Moved";
-    return (deliver);
-  }
 }


### PR DESCRIPTION
## The Issue

- #32

## How This PR Solves The Issue

Varnish should run only for `web:80`, not for all ports.

This PR changes the logic to route `web:80` through Varnish, while leaving everything else (Mailpit, `web_extra_exposed_ports`) unchanged.

This removes the need for `novarnish.*` subdomains.

## Manual Testing Instructions

Prepare project:

```bash
mkdir varnish-test && cd varnish-test
printf "<?php\necho 'index' . PHP_EOL;\n" >index.php
ddev config --auto
mkdir -p php-extra
printf "<?php\necho 'php-extra' . PHP_EOL;\n" >php-extra/index.php
cat >>.ddev/config.yaml <<'EOF'
web_extra_daemons:
    - name: "php-extra"
      command: "php -S 0.0.0.0:20080"
      directory: /var/www/html/php-extra
web_extra_exposed_ports:
    - name: "php-extra"
      container_port: 20080
      http_port: 20080
      https_port: 20443
EOF
```

Install add-on:
```
ddev add-on get https://github.com/ddev/ddev-varnish/tarball/refs/pull/46/head
ddev restart
```

And test it:
```
# All the URLs should work without any redirects:
ddev launch
ddev mailpit
ddev launch :20443
```

Only this url should have Varnish headers:
```
$ ddev exec 'curl -I $DDEV_PRIMARY_URL'
HTTP/2 200 
accept-ranges: bytes
age: 0
content-type: text/html; charset=UTF-8
date: Mon, 22 Sep 2025 13:09:22 GMT
server: nginx
vary: Accept-Encoding
via: 1.1 varnish (Varnish/6.0)
x-varnish: 2
content-length: 6
```

Mailpit: no Varnish headers:
```
$ ddev exec 'curl -I $DDEV_PRIMARY_URL:8026'
HTTP/2 405 
date: Mon, 22 Sep 2025 13:10:09 GMT
```

web_extra_exposed_ports: no Varnish headers:
```
$ ddev exec 'curl -I $DDEV_PRIMARY_URL:20443'
HTTP/2 200 
content-type: text/html; charset=UTF-8
date: Mon, 22 Sep 2025 13:11:00 GMT
host: varnish-test.ddev.site:20443
x-powered-by: PHP/8.3.25
```

## Automated Testing Overview

I added test coverage for everything.

## Release/Deployment Notes

This should be released as major v1.0.0.