### PR TITLE
feat: use bash for `ddev ssh -s varnish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ This add-on also providers several helper commands. These helpers allow develope
 | `ddev varnishstat`           | Display Varnish Cache statistics                          |
 | `ddev varnishtest`           | Test program for Varnish                                  |
 | `ddev varnishtop`            | Display Varnish log entry ranking                         |
-| `ddev logs -s varnish`       | Check Varnish logs                                        |
 | `ddev varnish-config-reload` | Reloads the varnish current config to apply changes       |
+| `ddev describe`              | View service status and used ports for Varnish            |
+| `ddev ssh -s varnish`        | Go into the Varnish container shell                       |
+| `ddev logs -s varnish`       | Check Varnish logs                                        |
 
 See [The Varnish Reference Manual](https://varnish-cache.org/docs/6.0/reference/index.html) for more information about the commands, their flags, and their arguments.
 

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -16,6 +16,9 @@ services:
       # your default.vcl should be.
       - "./varnish:/etc/varnish"
       - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
     depends_on:
       - web
     entrypoint: docker-varnish-entrypoint ${VARNISH_VARNISHD_PARAMS:--p http_max_hdr=1000 -p http_resp_hdr_len=1M -p http_resp_size=2M -p workspace_backend=3M -p workspace_client=3M}
+    x-ddev:
+      ssh-shell: bash

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -51,6 +51,11 @@ setup() {
 }
 
 health_checks() {
+  # Check that bash is available in the varnish container
+  run ddev exec -s varnish command -v bash
+  assert_success
+  assert_output --partial "bash"
+
   # Test that .ddev/docker-compose.varnish_extra.yaml created correct env vars
   run ddev exec echo "\$HTTP_EXPOSE"
   assert_success


### PR DESCRIPTION
## The Issue

https://docs.ddev.com/en/stable/users/extend/in-container-configuration/#changing-ddev-ssh-shell

## How This PR Solves The Issue

Uses `bash`

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-varnish/tarball/refs/pull/48/head
ddev restart
ddev ssh -s varnish # see bash
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
